### PR TITLE
big upgrade: support embedded structs

### DIFF
--- a/ast_constructor.v
+++ b/ast_constructor.v
@@ -49,57 +49,105 @@ type Instruction = Assignment
 fn ast_constructor(tree Tree) VAST {
 	mut v_ast := VAST{}
 
-	v_ast.create_module(tree)
-
-	for _, decl in tree.child['Decls'].tree.child.clone() {
-		match decl.tree.child['Tok'].val {
-			// package imports
-			'import' {
-				v_ast.create_imports(decl.tree)
-			}
-			'type' {
-				if decl.tree.child['Specs'].tree.child['0'].tree.child['Type'].tree.name == '*ast.StructType' {
-					v_ast.create_structs(decl.tree)
-				} else {
-					v_ast.create_types(decl.tree)
-				}
-			}
-			else {}
-		}
+	v_ast.get_module(tree)
+	for _, el in tree.child['Decls'].tree.child.clone() {
+		v_ast.get_decl(el.tree, false)
 	}
 
 	return v_ast
 }
 
-fn (mut v VAST) create_module(tree Tree) {
+fn (mut v VAST) get_decl(tree Tree, embedded bool) {
+	// Go AST structure is different if embedded or not
+	base := if embedded { tree.child['Decl'].tree } else { tree.child['Specs'].tree.child['0'].tree }
+	type_field_name := if embedded { 'Kind' } else { 'Tok' }
+
+	match tree.child[type_field_name].val {
+		// Will never be embedded
+		'import' {
+			v.get_imports(tree)
+		}
+		'type' {
+			if base.child['Type'].tree.name == '*ast.StructType' {
+				v.get_structs(base)
+			} else if base.name != '' {
+				v.get_types(base)
+			}
+		}
+		'const' {
+			v.get_consts(base)
+		}
+		else {}
+	}
+}
+
+fn (mut v VAST) get_module(tree Tree) {
 	v.@module = tree.child['Name'].tree.child['Name'].val#[1..-1]
 }
 
-fn (mut v VAST) create_imports(tree Tree) {
+fn (mut v VAST) get_imports(tree Tree) {
 	for _, imp in tree.child['Specs'].tree.child {
 		v.imports << imp.tree.child['Path'].tree.child['Value'].val#[3..-3]
 	}
 }
 
-fn (mut v VAST) create_structs(tree Tree) {
-	base := tree.child['Specs'].tree.child['0']
+fn (mut v VAST) get_structs(tree Tree) {
 	mut @struct := StructLike{
-		name: base.tree.child['Name'].tree.child['Name'].val#[1..-1]
+		name: tree.child['Name'].tree.child['Name'].val#[1..-1]
 	}
 
-	for _, raw_field in base.tree.child['Type'].tree.child['Fields'].tree.child['List'].tree.child {
+	for _, raw_field in tree.child['Type'].tree.child['Fields'].tree.child['List'].tree.child {
 		mut val := ''
+		mut temp := raw_field.tree.child['Type']
+
 		if raw_field.tree.child['Type'].tree.name == '*ast.ArrayType' {
-			val = '[]' +
-				raw_field.tree.child['Type'].tree.child['Elt'].tree.child['Name'].val#[1..-1]
-		} else {
-			val = raw_field.tree.child['Type'].tree.child['Name'].val#[1..-1]
+			val = '[]'
+			temp = raw_field.tree.child['Type'].tree.child['Elt']
 		}
-		@struct.fields[raw_field.tree.child['Names'].tree.child['0'].tree.child['Name'].val#[1..-1]] = val
+
+		@struct.fields[raw_field.tree.child['Names'].tree.child['0'].tree.child['Name'].val#[1..-1]] =
+			val + temp.tree.child['Name'].val#[1..-1]
+
+		// check if item embedded
+		if 'Obj' in temp.tree.child {
+			v.get_decl(temp.tree.child['Obj'].tree, true)
+		}
 	}
+
 	v.structs << @struct
 }
 
-fn (mut v VAST) create_types(tree Tree) {
-	v.types[tree.child['Specs'].tree.child['0'].tree.child['Name'].tree.child['Name'].val#[1..-1]] = tree.child['Specs'].tree.child['0'].tree.child['Type'].tree.child['Name'].val#[1..-1]
+fn (mut v VAST) get_types(tree Tree) {
+	mut val := ''
+	mut temp := tree.child['Type']
+
+	if tree.child['Type'].tree.name == '*ast.ArrayType' {
+		val = '[]'
+		temp = tree.child['Type'].tree.child['Elt']
+	}
+
+	v.types[tree.child['Name'].tree.child['Name'].val#[1..-1]] = val +
+		temp.tree.child['Name'].val#[1..-1]
+
+	// check if item embedded
+	if 'Obj' in temp.tree.child {
+		v.get_decl(temp.tree.child['Obj'].tree, true)
+	}
+}
+
+fn (mut v VAST) get_consts(tree Tree) {
+	base := tree.child['Values'].tree.child['0'].tree
+	mut raw_val := if base.child['Value'].val.len != 0 {
+		base.child['Value'].val // everything except bools
+	} else {
+		base.child['Name'].val // bools
+	}
+
+	raw_val = match raw_val[1] {
+		`\\` { "'${raw_val#[3..-3]}'" } // strings
+		`'` { '`${raw_val#[2..-2]}`' } // runes
+		else { raw_val#[1..-1] } // numbers & bools
+	}
+
+	v.consts[tree.child['Names'].tree.child['0'].tree.child['Name'].val#[1..-1]] = raw_val
 }

--- a/test.go
+++ b/test.go
@@ -5,26 +5,36 @@ import (
 	"io"
 )
 
-type Ok = int
+type Type1 = int
+type Type2 = []string
+type Type3 = []Struct1
 
-type Oui struct {
+type Struct1 struct {
 	a int
 	b string
 }
 
-type Non struct {
+type Struct2 struct {
 	c []int
-	d []Oui
+	d []Struct1
+	e Struct3
 }
 
-const LOL = 123
+type Struct3 struct {
+	f int
+}
+
+const STRUCT_UPPERCASE_TO_HANDLE = 123
+const struct1 = "dsfsdfs"
+const struct2 = 'a'
+const struct3 = true
 
 func main() {
 	fmt.Println("Hello, World!")
-	io.EOF
+	fmt.Println(io.EOF)
 	//println(ok())
 }
 
-func ok() int {
+func func1() int {
 	return 1
 }

--- a/v_file_constructor.v
+++ b/v_file_constructor.v
@@ -4,6 +4,7 @@ fn v_file_constructor(v_ast VAST) string {
 	v.handle_imports()
 	v.handle_types()
 	v.handle_structs()
+	v.handle_consts()
 
 	return v.out.str()
 }
@@ -36,4 +37,18 @@ fn (mut v VAST) handle_structs() {
 		v.out.writeln('}')
 		v.out.writeln('')
 	}
+}
+
+fn (mut v VAST) handle_consts() {
+	if v.consts.len == 1 {
+		key := v.consts.keys()[0]
+		v.out.writeln('const $key = ${v.consts[key]}')
+	} else {
+		v.out.writeln('const (')
+		for key, val in v.consts {
+			v.out.writeln('\t$key = $val')
+		}
+		v.out.writeln(')')
+	}
+	v.out.writeln('')
 }


### PR DESCRIPTION
- support embedded structs in structs and sumtypes
- better test.go
- consts support
- better naming for methods of VAST

explanation of `support embedded structs in structs and sumtypes`:

in Go, this
```go
type Struct1 struct {}

type Struct2 struct {}
```
results in the following AST
```
AST
↪ AST for Struct1
↪ AST for Struct2
```
but this
```go
type Struct1 struct {
  a Struct2
}

type Struct2 struct {}
```
results in
```
AST
↪ AST for Struct1
  ↪ AST for Struct2
```

That's why embedded things support is so important, because this behaviour is the same for a function called inside a function.