### PR TITLE
feat: add test creation options

### DIFF
--- a/go2v.v
+++ b/go2v.v
@@ -4,9 +4,21 @@ import os
 import cli
 import transpiler
 
+const (
+	v_exe     = @VEXE
+	go2v_path = @VMODROOT
+)
+
 fn main() {
 	mut app := cli.Command{
 		name: 'go2v'
+		flags: [
+			cli.Flag{
+				flag: .bool
+				name: 'help'
+				abbrev: 'h'
+			},
+		]
 		description: 'Go2V is a CLI utility to transpile Go source code into V source code.'
 		execute: fn (cmd cli.Command) ? {
 			if cmd.args.len == 0 { println('At least one file or directory must be given, see "go2v help"') } else { transpiler.go_to_v(cmd.args[0], cmd.args[2] or {
@@ -26,18 +38,69 @@ fn main() {
 			},
 			cli.Command{
 				name: 'test'
+				flags: [
+					cli.Flag{
+						flag: .bool
+						name: 'compact'
+						description: 'do not output build stats'
+					},
+					cli.Flag{
+						flag: .string
+						name: 'create'
+						description: 'create new test'
+					},
+					cli.Flag{
+						flag: .string
+						name: 'out'
+						description: 'save output of test'
+					}
+				]
 				execute: fn (cmd cli.Command) ? {
-					mut stats := ''
-					if cmd.args.len == 0 {
-						stats = '-stats'
-					} else if cmd.args[0] == '-compact' {
-						stats = ''
-					} else {
-						println('At least one file or directory must be given, see "go2v help test"')
+					compact := cmd.flags.get_bool('compact') ?
+					create := cmd.flags.get_string('create') ?
+					out := cmd.flags.get_string('out') ?
+					if create != '' && out != '' {
+						println('Cannot use -create and -out at the same time')
 						return
 					}
 
-					os.execvp('${@VEXE}', [stats, 'test', os.resource_abs_path('.')]) ?
+					if create != '' {
+						if os.exists('$go2v_path/tests/$create') {
+							println('$go2v_path/tests/$create already exists - remove it if you want to create a new test with the same name')
+							return
+						}
+						os.mkdir('$go2v_path/tests/$create') ?
+						os.write_file('$go2v_path/tests/$create/${create}.go', 'package main\n') ?
+						println('$go2v_path/tests/$create/${create}.go created')
+					} else if out != '' {
+						if os.is_dir('$go2v_path/tests/$out/${out}.vv') {
+							println('$go2v_path/tests/$out/${out}.vv is a directory - remove it before trying to save output')
+							return
+						}
+						mut go2v_exe := ''
+						$if windows {
+							go2v_exe = '$go2v_path/go2v.exe'
+						} $else {
+							go2v_exe = '$go2v_path/go2v'
+						}
+						if os.exists(go2v_exe) {
+							os.execute('$go2v_exe $go2v_path/tests/$out/${out}.go -o $go2v_path/tests/$out/${out}.vv')
+						} else {
+							os.execute('${@VEXE} run $go2v_path $go2v_path/tests/$out/${out}.go -o $go2v_path/tests/$out/${out}.vv')
+						}
+						println('$go2v_path/tests/$out/${out}.vv saved')
+					} else if compact {
+						os.execvp('${@VEXE}', [
+							'test',
+							os.resource_abs_path(cmd.args[0]),
+						]) ?
+					} else {
+						os.execvp('${@VEXE}', [
+							'-stats',
+							'test',
+							os.resource_abs_path(cmd.args[0]),
+						]) ?
+					}
 					return
 				}
 			},

--- a/help/test.txt
+++ b/help/test.txt
@@ -3,4 +3,20 @@ Usage:
     Go2V tests itself with its testing suite located in `tests`.
 
 Options:
-  -compact     - Run tets without the `-stats` option.
+  -compact       - Run tests without the `-stats` option.
+  -create <name> - Create a new tests/<name> directory, with an empty <name>.go file
+  -out <name>    - Run go2v to generate a tests/<name>/<name>.vv file
+
+Creating a new test for go2v requires 2 steps.
+
+Step 1. go2v test -create new_test_name
+
+This will create a new subdirectory under tests, using the given name, and also
+create an "empty" .go file in the same subdirectory, also using the given name.
+
+Once you have edited the new_test_name.go file, run
+
+Step 2. go2v test -out new_test_name
+
+to generate the tests/new_test_name/new_test_name.vv file which will be compared
+against the output of go2v in the future, to ensure the output hasn't changed.


### PR DESCRIPTION
This adds `-create` and `-out` options to go2v test.

help.txt updated, as well as some cleanup on command-line handling.