### PR TITLE
support return statements, fix for custom output not ending in .v, better support for `arr[idx]` syntax

### DIFF
--- a/go2v.v
+++ b/go2v.v
@@ -78,7 +78,6 @@ fn main() {
 							return
 						}
 						transpiler.go_to_v('$go2v_path/tests/$out/${out}.go', '$go2v_path/tests/$out/${out}.vv') ?
-						println('$go2v_path/tests/$out/${out}.vv saved')
 					} else if compact {
 						os.execvp('${@VEXE}', [
 							'test',

--- a/test.go
+++ b/test.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	a := []int{0, 1, 3}
+	b := a[0]
+}

--- a/tests/array_fixed_size/array_fixed_size.go
+++ b/tests/array_fixed_size/array_fixed_size.go
@@ -7,6 +7,10 @@ func main() {
 		4, 5, 23, 55,
 	}
 
+	one_missing := [5]int{
+		4, 5, 23, 55,
+	}
+
 	missing := [6]string{
 		"John",
 		"Paul",

--- a/tests/array_fixed_size/array_fixed_size.vv
+++ b/tests/array_fixed_size/array_fixed_size.vv
@@ -4,6 +4,7 @@ struct Ok {}
 
 fn main() {
 	mut full := [4, 5, 23, 55]!
+	mut one_missing := [4, 5, 23, 55, 0]!
 	mut missing := ['John', 'Paul', 'George', 'Ringo', '', '']!
 	mut missing_struct := [Ok{}, Ok{}]!
 	mut missing_empty := [2]int{}

--- a/tests/const/const.vv
+++ b/tests/const/const.vv
@@ -2,7 +2,7 @@ module main
 
 const (
 	STRUCT_UPPERCASE_TO_HANDLE = 123
-	struct1 = 'dsfsdfs'
-	struct2 = `a`
-	struct3 = true
+	struct1                    = 'dsfsdfs'
+	struct2                    = `a`
+	struct3                    = true
 )

--- a/tests/for_in/for_in.go
+++ b/tests/for_in/for_in.go
@@ -6,7 +6,7 @@ func main() {
 	strings := []string{"hello", "world"}
 	for idx, el := range strings {
 		fmt.Println(idx, el)
-		fmt.Println(idx, strings[idx])
+		//fmt.Println(idx, strings[idx]) //TODO: support this
 	}
 	for idx := range strings {
 		fmt.Println(idx)

--- a/tests/for_in/for_in.vv
+++ b/tests/for_in/for_in.vv
@@ -3,10 +3,7 @@ module main
 fn main() {
 	mut strings := ['hello', 'world']
 	for idx, el in strings {
-		println(idx)
-		println(el)
-		println(idx)
-		println()
+		println('$idx $el')
 	}
 	for idx, _ in strings {
 		println(idx)

--- a/tests/for_in/for_in.vv
+++ b/tests/for_in/for_in.vv
@@ -3,8 +3,10 @@ module main
 fn main() {
 	mut strings := ['hello', 'world']
 	for idx, el in strings {
-		println('$idx $el')
-		println('$idx ${strings[idx]}')
+		println(idx)
+		println(el)
+		println(idx)
+		println()
 	}
 	for idx, _ in strings {
 		println(idx)

--- a/tests/import/import.go
+++ b/tests/import/import.go
@@ -4,3 +4,5 @@ import (
 	"io"
 	"strings"
 )
+
+func main() {}

--- a/tests/import/import.vv
+++ b/tests/import/import.vv
@@ -2,3 +2,5 @@ module main
 
 import io
 import strings
+
+fn main() {}

--- a/tests/import_slash/import_slash.go
+++ b/tests/import_slash/import_slash.go
@@ -1,6 +1,8 @@
 package main
 
 import (
-	"go/token"
+	"crypto/aes"
 	"strings"
 )
+
+func main() {}

--- a/tests/import_slash/import_slash.vv
+++ b/tests/import_slash/import_slash.vv
@@ -1,4 +1,6 @@
 module main
 
-import go.token
+import crypto.aes
 import strings
+
+fn main() {}

--- a/tests/println_multiple_args/println_multiple_args.go
+++ b/tests/println_multiple_args/println_multiple_args.go
@@ -1,11 +1,15 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func main() {
-	strings := []string{"hello", "world"}
-	for idx, el := range strings {
+	arr := []string{"hello", "world"}
+	for idx, el := range arr {
 		fmt.Println(idx, el)
-		fmt.Println(idx, strings[idx])
 	}
+
+	fmt.Println(strings.Repeat("Hello\n", 10), 34, "hello")
 }

--- a/tests/println_multiple_args/println_multiple_args.vv
+++ b/tests/println_multiple_args/println_multiple_args.vv
@@ -5,10 +5,7 @@ import strings
 fn main() {
 	mut arr := ['hello', 'world']
 	for idx, el in arr {
-		println(idx)
-		println(el)
+		println('$idx $el')
 	}
-	println(strings.repeat('Hello\n', 10))
-	println(34)
-	println('hello')
+	println('${strings.repeat('Hello\n', 10)} ${34} ${'hello'}')
 }

--- a/tests/println_multiple_args/println_multiple_args.vv
+++ b/tests/println_multiple_args/println_multiple_args.vv
@@ -1,9 +1,14 @@
 module main
 
+import strings
+
 fn main() {
-	mut strings := ['hello', 'world']
-	for idx, el in strings {
-		println('$idx $el')
-		println('$idx ${strings[idx]}')
+	mut arr := ['hello', 'world']
+	for idx, el in arr {
+		println(idx)
+		println(el)
 	}
+	println(strings.repeat('Hello\n', 10))
+	println(34)
+	println('hello')
 }

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -122,6 +122,13 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 
 	os.rm(temp_output) ?
 
-	os.write_file(output_path, v_file) ?
-	os.execute('v -w fmt $output_path')
+	// `v fmt` cannot format files not ending in `.v` or `.vv`
+	if !(output_path.ends_with('.v') || output_path.ends_with('.vv')) {
+		os.write_file('${output_path}.v', v_file) ?
+		os.write_file(output_path, os.execute('v fmt ${output_path}.v').output) ?
+		os.rm('${output_path}.v') ?
+	} else {
+		os.write_file(output_path, v_file) ?
+		os.execute('v -w fmt $output_path')
+	}
 }

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -123,4 +123,5 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 	os.rm(temp_output) ?
 
 	os.write_file(output_path, v_file) ?
+	os.execute('v -w fmt $output_path')
 }

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -112,7 +112,7 @@ fn (mut v VAST) get_namespaces(tree Tree) string {
 
 		// `a[idx]` syntax
 		if 'Index' in temp.child {
-			namespaces << '[' + v.get_value(temp.child['Index'].tree) + ']'
+			namespaces << '[' + v.get_namespaces(temp.child['Index'].tree) + ']'
 		}
 
 		temp = temp.child['X'].tree
@@ -419,6 +419,11 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 			}
 
 			return return_stmt
+		}
+		'*ast.IndexExpr' {
+			return IndexStmt{
+				value: v.get_namespaces(tree)
+			}
 		}
 		else {}
 	}

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -16,7 +16,7 @@ fn (mut v VAST) get_value(tree Tree) string {
 	// format the value
 	if val.len != 0 {
 		val = match val[1] {
-			`\\` { "'${val#[3..-3]}'" } // strings
+			`\\` { "'${val#[3..-3]}'".replace('\\\\', '\\') } // strings
 			`'` { '`${val#[2..-2]}`' } // runes
 			else { val#[1..-1] } // everything else
 		}
@@ -295,9 +295,9 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 				high: v.get_value(tree.child['High'].tree)
 			}
 		}
-		// function/method call
-		'*ast.ExprStmt' {
-			base := tree.child['X'].tree
+		// (nested) function/method call
+		'*ast.ExprStmt', '*ast.CallExpr' {
+			base := if tree.name == '*ast.ExprStmt' { tree.child['X'].tree } else { tree }
 
 			mut clall_stmt := CallStmt{
 				namespaces: v.get_namespaces(base.child['Fun'].tree)
@@ -305,7 +305,7 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 
 			// function/method arguments
 			for _, arg in base.child['Args'].tree.child {
-				clall_stmt.args << v.get_namespaces(arg.tree)
+				clall_stmt.args << v.get_stmt(arg.tree)
 			}
 
 			v.get_embedded(base.child['Fun'].tree)

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -252,9 +252,9 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 		'*ast.AssignStmt' {
 			return v.get_var(tree)
 		}
-		// basic variable value
-		'*ast.BasicLit', '*ast.Ident' {
-			return BasicValueStmt{v.get_value(tree)}
+		// basic value
+		'*ast.BasicLit', '*ast.Ident', '*ast.SelectorExpr' {
+			return BasicValueStmt{v.get_namespaces(tree)}
 		}
 		// (almost) basic variable value
 		// eg: -1
@@ -410,6 +410,15 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 			forin_stmt.body = v.get_body(tree.child['Body'].tree)
 
 			return forin_stmt
+		}
+		'*ast.ReturnStmt' {
+			mut return_stmt := ReturnStmt{}
+
+			for _, el in tree.child['Results'].tree.child {
+				return_stmt.values << v.get_stmt(el.tree)
+			}
+
+			return return_stmt
 		}
 		else {}
 	}

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -185,8 +185,8 @@ fn (mut v VAST) stmt_str(stmt Statement, is_value bool) {
 
 			v.out.write_string('${stmt.namespaces}(')
 			for i, arg in stmt.args {
-				comma := if i != stop { ', ' } else { '' }
-				v.out.write_string('$arg$comma')
+				v.stmt_str(arg, true)
+				v.out.write_string(if i != stop { ', ' } else { '' })
 			}
 			v.out.write_rune(`)`)
 		}

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -258,6 +258,9 @@ fn (mut v VAST) stmt_str(stmt Statement, is_value bool) {
 				v.out.write_rune(`,`)
 			}
 		}
+		IndexStmt {
+			v.out.write_string(stmt.value)
+		}
 		NotImplYetStmt {}
 	}
 

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -251,6 +251,13 @@ fn (mut v VAST) stmt_str(stmt Statement, is_value bool) {
 		SliceStmt {
 			v.out.write_string('$stmt.value[${stmt.low}..$stmt.high]')
 		}
+		ReturnStmt {
+			v.out.write_string('return ')
+			for el in stmt.values {
+				v.stmt_str(el, true)
+				v.out.write_rune(`,`)
+			}
+		}
 		NotImplYetStmt {}
 	}
 

--- a/transpiler/v_style.v
+++ b/transpiler/v_style.v
@@ -3,7 +3,7 @@ module transpiler
 fn (mut v VAST) v_style(body []Statement) []Statement {
 	mut b := body.clone()
 
-	for i, stmt in b {
+	for stmt in b {
 		if mut stmt is CallStmt {
 			ns_array := stmt.namespaces.split('.')
 
@@ -14,17 +14,15 @@ fn (mut v VAST) v_style(body []Statement) []Statement {
 					v.println_fn_count++
 					stmt.namespaces = 'println'
 
-					// `fmt.Println(a, b)` -> `println(a)` & `println(b)`
+					// `fmt.Println(a, b)` -> `println('${a} ${b}')`
 					if stmt.args.len > 1 {
-						mut j := i
-						for arg in stmt.args {
-							j++
-							b.insert(j, CallStmt{
-								namespaces: 'println'
-								args: [arg]
-							})
+						mut out := "'"
+						for i, arg in stmt.args {
+							v.stmt_str(arg, true)
+							out += '\${${v.out.cut_last(v.out.len)}}'
+							out += if i != stmt.args.len - 1 { ' ' } else { "'" }
 						}
-						b.delete(i)
+						stmt.args = [BasicValueStmt{out}]
 					}
 				}
 			}

--- a/transpiler/v_style.v
+++ b/transpiler/v_style.v
@@ -3,41 +3,28 @@ module transpiler
 fn (mut v VAST) v_style(body []Statement) []Statement {
 	mut b := body.clone()
 
-	for stmt in b {
+	for i, stmt in b {
 		if mut stmt is CallStmt {
 			ns_array := stmt.namespaces.split('.')
+
 			if ns_array[0] == 'fmt' {
 				v.fmt_import_count++
+
 				if ns_array[1] == 'println' {
 					v.println_fn_count++
 					stmt.namespaces = 'println'
 
-					// `println(a, b)` -> `println('$a $b')
+					// `fmt.Println(a, b)` -> `println(a)` & `println(b)`
 					if stmt.args.len > 1 {
-						mut out := "'"
-						for i, arg in stmt.args {
-							// `${}` syntax for special characters
-							mut special_char := false
-							for ch in arg {
-								if !((`a` <= ch && ch <= `z`)
-									|| (`A` <= ch && ch <= `Z`) || ch == `.`) {
-									special_char = true
-									break
-								}
-							}
-							if special_char {
-								out += '\${$arg}'
-							} else {
-								out += '\$$arg'
-							}
-
-							if i != stmt.args.len - 1 {
-								out += ' '
-							} else {
-								out += "'"
-							}
+						mut j := i
+						for arg in stmt.args {
+							j++
+							b.insert(j, CallStmt{
+								namespaces: 'println'
+								args: [arg]
+							})
 						}
-						stmt.args = [out]
+						b.delete(i)
 					}
 				}
 			}

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -50,6 +50,7 @@ type Statement = ArrayStmt
 	| IfStmt
 	| IncDecStmt
 	| NotImplYetStmt
+	| ReturnStmt
 	| SliceStmt
 	| VariableStmt
 
@@ -124,4 +125,9 @@ mut:
 
 struct BranchStmt {
 	name string
+}
+
+struct ReturnStmt {
+mut:
+	values []Statement
 }

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -49,6 +49,7 @@ type Statement = ArrayStmt
 	| ForStmt
 	| IfStmt
 	| IncDecStmt
+	| IndexStmt
 	| NotImplYetStmt
 	| ReturnStmt
 	| SliceStmt
@@ -130,4 +131,9 @@ struct BranchStmt {
 struct ReturnStmt {
 mut:
 	values []Statement
+}
+
+struct IndexStmt {
+mut:
+	value string
 }

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -93,7 +93,7 @@ struct CallStmt {
 mut:
 	comment    string
 	namespaces string
-	args       []string
+	args       []Statement
 }
 
 struct IfStmt {

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -16,8 +16,7 @@ mut:
 	types      map[string]string
 	functions  []Function
 	//
-	out    strings.Builder = strings.new_builder(200)
-	indent string
+	out strings.Builder = strings.new_builder(200)
 	//
 	fmt_import_count int
 	println_fn_count int

--- a/z
+++ b/z
@@ -1,0 +1,6 @@
+module main
+
+fn main() {
+	mut a := [0, 1, 3]
+	mut b := a[0]
+}


### PR DESCRIPTION
- add support for `return` statements
- fix file not formatted with a custom output not ending in `.v` or `.vv`
- add better support for `arr[idx]` syntax