### PR TITLE
support explicit type in variable declaration, support type casting, fix a[0] = "val" transformation, fix `a = fn()` transformation, support defer stmts

### DIFF
--- a/tests/defer/defer.go
+++ b/tests/defer/defer.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	defer fmt.Println("world")
+
+	fmt.Println("hello")
+}

--- a/tests/defer/defer.vv
+++ b/tests/defer/defer.vv
@@ -1,0 +1,8 @@
+module main
+
+fn main() {
+	defer {
+		println('world')
+	}
+	println('hello')
+}

--- a/tests/type_cast/type_cast.go
+++ b/tests/type_cast/type_cast.go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+	i := 42
+	f := float64(i)
+	u := int16(f)
+}

--- a/tests/type_cast/type_cast.vv
+++ b/tests/type_cast/type_cast.vv
@@ -1,0 +1,7 @@
+module main
+
+fn main() {
+	mut i := 42
+	mut f := f64(i)
+	mut u := i16(f)
+}

--- a/tests/var_explicit_type/var_explicit_type.go
+++ b/tests/var_explicit_type/var_explicit_type.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	var a uint64 = 12
+	var ok, ko int16 = 23, 34
+}

--- a/tests/var_explicit_type/var_explicit_type.vv
+++ b/tests/var_explicit_type/var_explicit_type.vv
@@ -1,0 +1,6 @@
+module main
+
+fn main() {
+	mut a := u64(12)
+	mut ok, ko := i16(23), i16(34)
+}

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -122,7 +122,7 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 
 	os.rm(temp_output) ?
 
-	// `v fmt` cannot format files not ending in `.v` or `.vv`
+	// workaround for custom output not ending in `.v` or `.vv` because `v fmt` cannot format those
 	if !(output_path.ends_with('.v') || output_path.ends_with('.vv')) {
 		os.write_file('${output_path}.v', v_file) ?
 		os.write_file(output_path, os.execute('v fmt ${output_path}.v').output) ?

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -1,5 +1,24 @@
 module transpiler
 
+// types equivalence (left Go & right V)
+const get_type = {
+	'bool':    'bool'
+	'string':  'string'
+	'byte':    'byte'
+	'rune':    'rune'
+	'int':     'int'
+	'int8':    'i8'
+	'int16':   'i16'
+	'int32':   'i32'
+	'int64':   'i64'
+	'uint8':   'u8'
+	'uint16':  'u16'
+	'uint32':  'u32'
+	'uint64':  'u64'
+	'float32': 'f32'
+	'float64': 'f64'
+}
+
 // get the value of a variable etc. Basically, everything that can be of multiple types
 fn (mut v VAST) get_value(tree Tree) string {
 	// get the raw value
@@ -246,6 +265,8 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 				names: names
 				middle: ':='
 				values: values
+				@type: transpiler.get_type[v.get_name(base.child['Type'].tree, false,
+					true)]
 			}
 		}
 		// `:=` & `=` syntax

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -1,23 +1,26 @@
 module transpiler
 
 // types equivalence (left Go & right V)
-const get_type = {
-	'bool':    'bool'
-	'string':  'string'
-	'byte':    'byte'
-	'rune':    'rune'
-	'int':     'int'
-	'int8':    'i8'
-	'int16':   'i16'
-	'int32':   'i32'
-	'int64':   'i64'
-	'uint8':   'u8'
-	'uint16':  'u16'
-	'uint32':  'u32'
-	'uint64':  'u64'
-	'float32': 'f32'
-	'float64': 'f64'
-}
+const (
+	get_type = {
+		'bool':    'bool'
+		'string':  'string'
+		'byte':    'byte'
+		'rune':    'rune'
+		'int':     'int'
+		'int8':    'i8'
+		'int16':   'i16'
+		'int32':   'i32'
+		'int64':   'i64'
+		'uint8':   'u8'
+		'uint16':  'u16'
+		'uint32':  'u32'
+		'uint64':  'u64'
+		'float32': 'f32'
+		'float64': 'f64'
+	}
+	go_types = get_type.keys()
+)
 
 // get the value of a variable etc. Basically, everything that can be of multiple types
 fn (mut v VAST) get_value(tree Tree) string {
@@ -53,39 +56,33 @@ fn (mut v VAST) get_value(tree Tree) string {
 
 // get the name of a variable/property/function etc.
 fn (mut v VAST) get_name(tree Tree, deep bool, snake_case bool) string {
-	// `a = ` syntax
-	if 'Name' in tree.child {
-		raw_name := if deep {
-			tree.child['Name'].tree.child['Name'].val#[1..-1]
-		} else {
-			tree.child['Name'].val#[1..-1]
-		}
-
-		if snake_case {
-			// convert to snake case
-			mut out := []rune{}
-
-			for i, ch in raw_name {
-				if `A` <= ch && ch <= `Z` {
-					if i != 0 {
-						out << `_`
-					}
-					out << ch + 32
-				} else {
-					out << ch
-				}
-			}
-
-			return out.string()
-		} else {
-			// capitalize
-			sub := if `A` <= raw_name[0] && raw_name[0] <= `Z` { 0 } else { 32 }
-
-			return (raw_name[0] - byte(sub)).ascii_str() + raw_name[1..]
-		}
+	raw_name := if deep {
+		tree.child['Name'].tree.child['Name'].val#[1..-1]
 	} else {
-		// `a.b.c = ` syntax
-		return v.get_namespaces(tree)
+		tree.child['Name'].val#[1..-1]
+	}
+
+	if snake_case {
+		// convert to snake case
+		mut out := []rune{}
+
+		for i, ch in raw_name {
+			if `A` <= ch && ch <= `Z` {
+				if i != 0 {
+					out << `_`
+				}
+				out << ch + 32
+			} else {
+				out << ch
+			}
+		}
+
+		return out.string()
+	} else {
+		// capitalize
+		sub := if `A` <= raw_name[0] && raw_name[0] <= `Z` { 0 } else { 32 }
+
+		return (raw_name[0] - byte(sub)).ascii_str() + raw_name[1..]
 	}
 }
 
@@ -142,6 +139,10 @@ fn (mut v VAST) get_namespaces(tree Tree) string {
 		if !('X' in temp.child['X'].tree.child || 'Sel' in temp.child) {
 			near_end = true
 		}
+	}
+
+	if namespaces.len == 1 && namespaces[0] in transpiler.go_types {
+		namespaces[0] = transpiler.get_type[namespaces[0]]
 	}
 
 	mut out := ''
@@ -211,7 +212,7 @@ fn (mut v VAST) get_var(tree Tree) VariableStmt {
 	mut values := []Statement{}
 
 	for _, name in tree.child['Lhs'].tree.child {
-		names << v.get_name(name.tree, false, true)
+		names << v.get_namespaces(name.tree)
 	}
 	for _, val in tree.child['Rhs'].tree.child {
 		values << v.get_stmt(val.tree) // TODO: support `variable := StructWithFields{0, "abc"}`

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -443,6 +443,9 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 
 			return return_stmt
 		}
+		'*ast.DeferStmt' {
+			return DeferStmt{v.get_stmt(tree.child['Call'].tree)}
+		}
 		'*ast.IndexExpr' {
 			return IndexStmt{
 				value: v.get_namespaces(tree)

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -267,6 +267,11 @@ fn (mut v VAST) handle_stmt(stmt Statement, is_value bool) {
 				v.out.write_rune(`,`)
 			}
 		}
+		DeferStmt {
+			v.out.write_string('defer {')
+			v.handle_stmt(stmt.value, true)
+			v.out.write_rune(`}`)
+		}
 		IndexStmt {
 			v.out.write_string(stmt.value)
 		}

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -160,9 +160,10 @@ fn (mut v VAST) handle_stmt(stmt Statement, is_value bool) {
 		}
 		CallStmt {
 			v.out.write_string('${stmt.namespaces}(')
-			for arg in stmt.args {
+			for i, arg in stmt.args {
 				v.handle_stmt(arg, true)
-				v.out.write_rune(`,`)
+				// TODO: useless after https://github.com/vlang/v/issues/13592 gets fixed
+				v.out.write_string(if i != stmt.args.len - 1 { ',' } else { '' })
 			}
 			v.out.write_rune(`)`)
 		}

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -126,6 +126,7 @@ fn (mut v VAST) handle_body(body []Statement) {
 fn (mut v VAST) handle_stmt(stmt Statement, is_value bool) {
 	match stmt {
 		VariableStmt {
+			has_explicit_type := stmt.@type.len > 0
 			stop := stmt.names.len - 1
 
 			if stmt.mutable && stmt.middle == ':=' {
@@ -143,7 +144,14 @@ fn (mut v VAST) handle_stmt(stmt Statement, is_value bool) {
 
 			// value(s)
 			for i, value in stmt.values {
+				// explicit type
+				if has_explicit_type {
+					v.out.write_string('${stmt.@type}(')
+				}
 				v.handle_stmt(value, true)
+				if has_explicit_type {
+					v.out.write_rune(`)`)
+				}
 				v.out.write_string(if i != stop { ',' } else { '' })
 			}
 		}

--- a/transpiler/v_style.v
+++ b/transpiler/v_style.v
@@ -1,30 +1,44 @@
 module transpiler
 
+fn (mut v VAST) style_print(stmt CallStmt) CallStmt {
+	mut s := stmt
+
+	ns_array := s.namespaces.split('.')
+
+	if ns_array[0] == 'fmt' {
+		v.fmt_import_count++
+
+		if ns_array[1] == 'println' || ns_array[1] == 'print' {
+			v.fmt_supported_fn_count++
+			s.namespaces = ns_array[1]
+
+			// `println(a, b)` -> `println('${a} ${b}')`
+			if s.args.len > 1 {
+				mut out := "'"
+				for i, arg in s.args {
+					v.handle_stmt(arg, true)
+					out += '\${${v.out.cut_last(v.out.len)}}'
+					out += if i != s.args.len - 1 { ' ' } else { "'" }
+				}
+				s.args = [BasicValueStmt{out}]
+			}
+		}
+	}
+
+	return s
+}
+
 fn (mut v VAST) v_style(body []Statement) []Statement {
 	mut b := body.clone()
 
 	for stmt in b {
 		if mut stmt is CallStmt {
-			ns_array := stmt.namespaces.split('.')
-
-			if ns_array[0] == 'fmt' {
-				v.fmt_import_count++
-
-				if ns_array[1] == 'println' || ns_array[1] == 'print' {
-					v.fmt_supported_fn_count++
-					stmt.namespaces = ns_array[1]
-
-					// `println(a, b)` -> `println('${a} ${b}')`
-					if stmt.args.len > 1 {
-						mut out := "'"
-						for i, arg in stmt.args {
-							v.handle_stmt(arg, true)
-							out += '\${${v.out.cut_last(v.out.len)}}'
-							out += if i != stmt.args.len - 1 { ' ' } else { "'" }
-						}
-						stmt.args = [BasicValueStmt{out}]
-					}
-				}
+			temp := v.style_print(stmt)
+			stmt.namespaces = temp.namespaces
+			stmt.args = temp.args
+		} else if mut stmt is DeferStmt {
+			if mut stmt.value is CallStmt {
+				stmt.value = v.style_print(stmt.value)
 			}
 		}
 	}

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -45,6 +45,7 @@ type Statement = ArrayStmt
 	| BasicValueStmt
 	| BranchStmt
 	| CallStmt
+	| DeferStmt
 	| ForInStmt
 	| ForStmt
 	| IfStmt
@@ -133,6 +134,11 @@ struct BranchStmt {
 struct ReturnStmt {
 mut:
 	values []Statement
+}
+
+struct DeferStmt {
+mut:
+	value Statement
 }
 
 struct IndexStmt {

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -65,6 +65,7 @@ mut:
 	middle  string
 	values  []Statement
 	mutable bool = true
+	@type   string
 }
 
 struct ArrayStmt {


### PR DESCRIPTION
- add support for explicit type in variable declaration
- add support for type casting
- add support for defer statements
- fix a[0] = "val" transformation
- fix `a = fn()` transformation