### PR TITLE
No temp go

### DIFF
--- a/transpiler/get_ast.go
+++ b/transpiler/get_ast.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -8,7 +9,9 @@ import (
 )
 
 func main() {
-	path := os.Args[1]
+	// parsing flags with none defined just makes input parameters start @ 0
+	flag.Parse()
+	path := flag.Arg(0)
 
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
@@ -19,5 +22,5 @@ func main() {
 	f, _ := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
 	defer f.Close()
 
-	ast.Fprint(f, fset, node, ast.NotNilFilter)
+	ast.Fprint(os.Stdout, fset, node, ast.NotNilFilter)
 }

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -10,15 +10,9 @@ struct InOut {
 
 // TODO: add a system with a watcher function to make the tree construction stage and possibly other stages concurrent
 
-const go2v_temp = '$os.temp_dir()/go2v_temp'
-
 pub fn go_to_v(input_path string, output_path string) ? {
 	if !os.exists(input_path) {
 		return error('"$input_path" is not a valid file/directory.')
-	}
-
-	if !os.exists(transpiler.go2v_temp) {
-		os.mkdir(transpiler.go2v_temp) ?
 	}
 
 	input_is_dir := os.is_dir(input_path)


### PR DESCRIPTION
Small speedup - no longer copies input to /tmp, so no need to clean anything after conversion.