### PR TITLE
feat: simplify non-v file output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ go2v.exe
 temp
 tests/**/out.vv
 test.go
+test.v
 z
 
 #MacOS

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -114,8 +114,8 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 	// workaround for custom output not ending in `.v` or `.vv` because `v fmt` cannot format those
 	if !(output_path.ends_with('.v') || output_path.ends_with('.vv')) {
 		os.write_file('${output_path}.v', v_file) ?
-		os.write_file(output_path, os.execute('v fmt ${output_path}.v').output) ?
-		os.rm('${output_path}.v') ?
+		os.execute('v fmt -w ${output_path}.v')
+		os.mv('${output_path}.v', output_path) ?
 	} else {
 		os.write_file(output_path, v_file) ?
 		os.execute('v -w fmt $output_path')


### PR DESCRIPTION
Saves a couple of operations when the output file isn't .v or .vv.