### PR TITLE
fix: write output even if fmt fails

### DIFF
--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -124,9 +124,9 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 	table := ast.new_table()
 	result := parser.parse_text(raw_v_file, output_path, table, .parse_comments, prefs)
 	if result.errors.len > 0 {
-        for e in result.errors {
-                eprintln(util.formatted_error('error:', e.message, output_path, e.pos))
-        }
+		for e in result.errors {
+			eprintln(util.formatted_error('error:', e.message, output_path, e.pos))
+		}
 		return error('Generated output could not be formatted:')
 	}
 	formatted_content := fmt.fmt(result, table, prefs, false)

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -6,6 +6,7 @@ import v.ast
 import v.fmt
 import v.pref
 import v.parser
+import v.util
 
 struct InOut {
 	input_path  string
@@ -115,15 +116,18 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 		os.write_file('temp/raw_file.v', raw_v_file) ?
 	}
 
+	os.write_file(output_path, raw_v_file) ?
+
 	mut prefs := &pref.Preferences{
 		output_mode: .silent
 	}
 	table := ast.new_table()
 	result := parser.parse_text(raw_v_file, output_path, table, .parse_comments, prefs)
 	if result.errors.len > 0 {
-		os.write_file(output_path, raw_v_file) ?
-
-		return error('Generated code could not be formatted:\n$result.errors')
+        for e in result.errors {
+                eprintln(util.formatted_error('error:', e.message, output_path, e.pos))
+        }
+		return error('Generated output could not be formatted:')
 	}
 	formatted_content := fmt.fmt(result, table, prefs, false)
 

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -115,10 +115,11 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 		os.write_file('temp/raw_file.v', raw_v_file) ?
 	}
 
-	mut prefs := &pref.Preferences{output_mode: .silent}
+	mut prefs := &pref.Preferences{
+		output_mode: .silent
+	}
 	table := ast.new_table()
-	result := parser.parse_text(raw_v_file, output_path, table, .parse_comments,
-		prefs)
+	result := parser.parse_text(raw_v_file, output_path, table, .parse_comments, prefs)
 	if result.errors.len > 0 {
 		os.write_file(output_path, raw_v_file) ?
 

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -115,12 +115,16 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 		os.write_file('temp/raw_file.v', raw_v_file) ?
 	}
 
-	mut prefs := pref.new_preferences()
-	prefs.is_fmt = true
+	mut prefs := &pref.Preferences{output_mode: .silent}
 	table := ast.new_table()
-	file_ast := parser.parse_text(raw_v_file, 'generated file', table, .parse_comments,
+	result := parser.parse_text(raw_v_file, output_path, table, .parse_comments,
 		prefs)
-	formatted_content := fmt.fmt(file_ast, table, prefs, false)
+	if result.errors.len > 0 {
+		os.write_file(output_path, raw_v_file) ?
+
+		return error('Generated code could not be formatted:\n$result.errors')
+	}
+	formatted_content := fmt.fmt(result, table, prefs, false)
 
 	// compile with -cg to enable this block
 	// only works properly if converting single file.


### PR DESCRIPTION
The "raw" (unformatted) version of the output file will now be written if there are formatting errors.

#49 needs to be merged first, then CI checks can be re-run on this before merging.