### PR TITLE
fix: move mkdir_all for output

### DIFF
--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -45,8 +45,6 @@ pub fn go_to_v(input_path string, output_path string) ? {
 			' - add trailing `/` to output if you wish the .v file to be generated in that directory')
 	}
 
-	os.mkdir_all(os.dir(out_path)) ?
-
 	if input_is_dir && os.is_file(out_path) {
 		return error('"$input_path" is a directory, but "$output_path" is a file')
 	}
@@ -107,6 +105,7 @@ pub fn convert_and_write(input_path string, output_path string) ? {
 		os.write_file('temp/raw_file.v', raw_v_file) ?
 	}
 
+	os.mkdir_all(os.dir(output_path)) ?
 	os.write_file(output_path, raw_v_file) ?
 
 	mut prefs := &pref.Preferences{


### PR DESCRIPTION
The `mkdir_all` for the output path has been moved to just before the converted file is written to disk.
This takes care of 2 things:

- it makes sure any subdirs are created from handling recursive input
- subdirs are no longer created if there's an error before the file has been successfully converted