### PR TITLE
fix: small fix for path handling

### DIFF
--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -36,10 +36,10 @@ pub fn go_to_v(input_path string, output_path string) ? {
 			out_path = '${input_path.all_before_last('.go')}.v'
 		}
 	} else if out_path.ends_with(os.path_separator) {
-		if os.is_file(os.dir(out_path)) {
+		out_path = os.dir(out_path)
+		if os.is_file(out_path) {
 			return error('"${os.dir(out_path)}" is a file, not a directory')
 		}
-		out_path = '$out_path${os.file_name(input_path).all_before_last('.go')}.v'
 	} else if input_is_file && os.is_dir(out_path) {
 		return error('"$input_path" is a file, but "$output_path" is a directory\n' +
 			' - add trailing `/` to output if you wish the .v file to be generated in that directory')
@@ -61,7 +61,10 @@ pub fn go_to_v(input_path string, output_path string) ? {
 			return error('"$input_path" is not a `.go` file')
 		}
 	} else {
-		for input in os.walk_ext(input_path, '.go') {
+		mut go_files := os.walk_ext(input_path, '.go')
+		go_files.sort()
+
+		for input in go_files {
 			outputs << InOut{
 				input_path: input
 				output_path: '$out_path/${os.file_name(input).all_before('.go')}.v'

--- a/transpiler/go2v.v
+++ b/transpiler/go2v.v
@@ -67,7 +67,7 @@ pub fn go_to_v(input_path string, output_path string) ? {
 		for input in go_files {
 			outputs << InOut{
 				input_path: input
-				output_path: '$out_path/${os.file_name(input).all_before('.go')}.v'
+				output_path: '$out_path/${input.all_after(input_path + os.path_separator).all_before('.go')}.v'
 			}
 		}
 

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -507,6 +507,6 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 }
 
 fn not_implemented(feature string) Statement {
-	eprintln("Go feature `$feature` not currently implemented\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new")
+	eprintln('Go feature `$feature` not currently implemented\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new')
 	return NotImplYetStmt{}
 }

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -507,6 +507,6 @@ fn (mut v VAST) get_stmt(tree Tree) Statement {
 }
 
 fn not_implemented(feature string) Statement {
-	eprintln("A feature in your Go code named `$feature` isn't currently implemented in Go2V, please check the resulting V code and report the missing feature at https://github.com/vlang/go2v/issues/new")
+	eprintln("Go feature `$feature` not currently implemented\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new")
 	return NotImplYetStmt{}
 }


### PR DESCRIPTION
Fixes a case where giving an output path could tack `.v` on the end of the directory.

Ensure matching subdirs in output.

Sort input files... nicer to see things handled "in order".

Shorten "not implemented" message and add `\n` to make it fit better.