### PR TITLE
complex & massive cleanup of `utils.v` functions `get_type`, `get_name`, & `get_namespaces`, rudimentary system adding more informations to not yet implemented features, fix type conversion in struct fields

### DIFF
--- a/tests/map/map.vv
+++ b/tests/map/map.vv
@@ -1,8 +1,8 @@
 module main
 
 struct Vertex {
-	lat  float64
-	long float64
+	lat  f64
+	long f64
 }
 
 fn main() {

--- a/tests/map_empty/map_empty.vv
+++ b/tests/map_empty/map_empty.vv
@@ -1,8 +1,8 @@
 module main
 
 struct Vertex {
-	lat  float64
-	long float64
+	lat  f64
+	long f64
 }
 
 fn main() {

--- a/tests/map_short/map_short.vv
+++ b/tests/map_short/map_short.vv
@@ -1,8 +1,8 @@
 module main
 
 struct Vertex {
-	lat  float64
-	long float64
+	lat  f64
+	long f64
 }
 
 fn main() {

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -533,12 +533,10 @@ fn not_implemented(tree Tree) Statement {
 		hint = 'at unknown character'
 	}
 
-	if hint != 'at unknown character' {
-		eprintln('Go feature `$tree.name` $hint not currently implemented.\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new')
+	if hint == 'at unknown character' && 'Tok' in tree.child {
+		return not_implemented(tree.child['X'].tree)
 	} else {
-		if 'Tok' in tree.child {
-			not_implemented(tree.child['X'].tree)
-		}
+		eprintln('Go feature `$tree.name` $hint not currently implemented.\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new')
 	}
 
 	return NotImplYetStmt{}

--- a/transpiler/utils.v
+++ b/transpiler/utils.v
@@ -536,7 +536,9 @@ fn not_implemented(tree Tree) Statement {
 	if hint != 'at unknown character' {
 		eprintln('Go feature `$tree.name` $hint not currently implemented.\nPlease report the missing feature at https://github.com/vlang/go2v/issues/new')
 	} else {
-		not_implemented(tree.child['X'].tree)
+		if 'Tok' in tree.child {
+			not_implemented(tree.child['X'].tree)
+		}
 	}
 
 	return NotImplYetStmt{}

--- a/transpiler/v_file_constructor.v
+++ b/transpiler/v_file_constructor.v
@@ -224,7 +224,8 @@ fn (mut v VAST) handle_stmt(stmt Statement, is_value bool) {
 				v.out.write_string(']${stmt.@type}{}')
 			} else {
 				for el in stmt.values {
-					v.out.write_string('$el, ')
+					v.handle_stmt(el, true)
+					v.out.write_rune(`,`)
 				}
 
 				mut i := stmt.values.len

--- a/transpiler/vast.v
+++ b/transpiler/vast.v
@@ -78,7 +78,7 @@ mut:
 struct ArrayStmt {
 mut:
 	@type  string
-	values []string
+	values []Statement
 	len    string
 }
 


### PR DESCRIPTION
- complex & massive cleanup of `utils.v` functions `get_type`, `get_name`, & `get_namespaces`
- add a rudimentary system adding more informations to not yet implemented features
- fix type conversion in struct fields