### PR TITLE
fix ci error of generic fmt

### DIFF
--- a/tests/fn_generic/fn_generic.vv
+++ b/tests/fn_generic/fn_generic.vv
@@ -1,3 +1,3 @@
 module main
 
-fn abc<T>(s T) {}
+fn abc[T](s T) {}

--- a/tests/match_type/match_type.vv
+++ b/tests/match_type/match_type.vv
@@ -1,6 +1,6 @@
 module main
 
-fn abc<T>(s T) {
+fn abc[T](s T) {
 	match s.type_name() {
 		'int' {
 			println('a')

--- a/tests/type_any/type_any.vv
+++ b/tests/type_any/type_any.vv
@@ -1,7 +1,7 @@
 module main
 
-fn write_rune<T>(a T) {}
+fn write_rune[T](a T) {}
 
-fn write_tune<T>(a_1 ...T) {}
+fn write_tune[T](a_1 ...T) {}
 
 fn write_fune(a_2 []T) {}


### PR DESCRIPTION
This PR fix ci error of generic fmt with the latest v compiler.