### PR TITLE
array_append: add missing brackets

### DIFF
--- a/assign_stmt.v
+++ b/assign_stmt.v
@@ -37,10 +37,21 @@ fn (mut app App) check_and_handle_append(assign AssignStmt) bool {
 
 fn (mut app App) gen_append(args []Expr) {
 	app.gen(' << ')
+	if args.len == 2 {
+		app.expr(args[1])
+		app.genln('')
+		return
+	}
+
 	for i := 1; i < args.len; i++ {
+		if i == 1 && args[i] is BasicLit {
+			app.gen('[')
+		}
 		app.expr(args[i])
 		if i < args.len - 1 {
 			app.gen(',')
+		} else if i == args.len - 1 && args[i] is BasicLit {
+			app.gen(']')
 		}
 	}
 	app.genln('')

--- a/tests/13.array_append.v
+++ b/tests/13.array_append.v
@@ -3,7 +3,7 @@ module main
 fn main() {
 	mut s := []int{}
 	s << 1
-	s << 2, 3, 4
+	s << [2, 3, 4]
 	mut a := [4, 5, 6]
 	mut b := [1, 2, 3]
 	b << a


### PR DESCRIPTION
tests/array_append.v was invalid due to missing brackets around the set of 3 values on the 2nd append.