### PR TITLE
fix: use package name from .go file as module name, fix asty install lookup

### DIFF
--- a/ast.v
+++ b/ast.v
@@ -27,6 +27,7 @@ type Stmt = AssignStmt
 	| SwitchStmt
 
 struct GoFile {
+	name  Ident  @[json: 'Name']
 	decls []Decl @[json: 'Decls']
 }
 

--- a/ast2json/ast2json.vsh
+++ b/ast2json/ast2json.vsh
@@ -8,7 +8,7 @@ if os.args.len != 2 {
 file := os.args[1]
 
 // Check if asty is installed
-asty_installed := os.system('go list -m -json github.com/asty-org/asty > /dev/null 2>&1') == 0
+asty_installed := os.system('go list -m -json github.com/asty-org/asty@latest > /dev/null 2>&1') == 0
 
 if !asty_installed {
 	println('asty not found, installing...')
@@ -21,28 +21,24 @@ if !asty_installed {
 
 // Run asty go2json
 output_file := '${file}.json'
-cmd := 'asty go2json -indent 2 -input $file -output $output_file'
+cmd := 'asty go2json -indent 2 -input ${file} -output ${output_file}'
 run_result := os.system(cmd)
 
 if run_result != 0 {
 	eprintln('Failed to run asty')
 	return
-
-
 }
 
+// Replace "NodeType": " with "_type": "
+json_content := os.read_file(output_file) or {
+	eprintln('Failed to read ${output_file}')
+	return
+}
 
-    // Replace "NodeType": " with "_type": "
-    json_content := os.read_file(output_file) or {
-        eprintln('Failed to read $output_file')
-        return
-    }
+updated_content := json_content.replace('"NodeType": "', '"_type": "')
 
-    updated_content := json_content.replace('"NodeType": "', '"_type": "')
-
-    os.write_file(output_file, updated_content) or {
-        eprintln('Failed to write to $output_file')
-        return
-    }
-println('Successfully converted $file to $output_file')
-
+os.write_file(output_file, updated_content) or {
+	eprintln('Failed to write to ${output_file}')
+	return
+}
+println('Successfully converted ${file} to ${output_file}')

--- a/main.v
+++ b/main.v
@@ -21,7 +21,7 @@ fn (mut app App) gen(s string) {
 }
 
 fn (mut app App) generate_v_code(go_file GoFile) string {
-	app.genln('module main\n')
+	app.genln('module ${go_file.name.name}\n')
 
 	for decl in go_file.decls {
 		match decl.node_type_str {


### PR DESCRIPTION
go2v was hard-coding the V module name as `main`.  Fixed.  No real effect right now (when all the test files have `package main`), but will definitely help later.

`go list -m` needs a version or an option.  ast2json.vsh was throwing away the output when `asty` couldn't be found, which was:
```
go: cannot match "github.com/asty-org/asty" without -versions or an explicit version: go.mod file not found in current directory or any parent directory; see 'go help modules'
```
Fixed by adding `@latest`.
