### PR TITLE
tests: init tests_ok = true

### DIFF
--- a/main.v
+++ b/main.v
@@ -33,7 +33,7 @@ struct App {
 mut:
 	sb         strings.Builder
 	is_fn_call bool // for lowercase idents
-	tests_ok   bool
+	tests_ok   bool = true
 }
 
 fn (mut app App) genln(s string) {


### PR DESCRIPTION
`app.tests_ok` was defaulting to `false` so `v run .` would always exit with `rc = 1`

Init with `= true` so it will only exit with `rc = 1` if one of the tests fails.